### PR TITLE
Avoid freeing ftve->val if it was not allocated

### DIFF
--- a/lib/ftvar.c
+++ b/lib/ftvar.c
@@ -78,7 +78,7 @@ void ftvar_free(struct ftvar *ftvar)
     if (ftve->name)
       free(ftve->name);
 
-    if (ftve->val);
+    if (ftve->val)
       free(ftve->val);
 
     FT_SLIST_REMOVE_HEAD(&ftvar->entries, chain);


### PR DESCRIPTION
```
ftvar.c:81:19: warning: if statement has empty body [-Wempty-body]
    if (ftve->val);
                  ^
ftvar.c:81:19: note: put the semicolon on a separate line to silence this warning
1 warning generated.
```